### PR TITLE
Added deinit for PBR maps

### DIFF
--- a/src/mtl.zig
+++ b/src/mtl.zig
@@ -158,6 +158,12 @@ pub const Material = struct {
         if (self.bump_map_path) |p| allocator.free(p);
         if (self.diffuse_map_path) |p| allocator.free(p);
         if (self.specular_map_path) |p| allocator.free(p);
+        if (self.ambient_map_path) |p| allocator.free(p);
+        if (self.roughness_map_path) |p| allocator.free(p);
+        if (self.metallic_map_path) |p| allocator.free(p);
+        if (self.sheen_map_path) |p| allocator.free(p);
+        if (self.emissive_map_path) |p| allocator.free(p);
+        if (self.normal_map_path) |p| allocator.free(p);
     }
 };
 


### PR DESCRIPTION
In the previous PR, PBR materials were added. 

But I actually forgot to implement the deinit for the new map locations. I'm sorry for that.

This PR fixes that. But I would advise you check if I haven't forgotten something else
